### PR TITLE
ANY 옵션 삭제 및 복수 백신 선택, 모든 기관 탐색

### DIFF
--- a/kakao/request.py
+++ b/kakao/request.py
@@ -88,8 +88,7 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
             close()
 
     if found is None:
-        find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bottom_y, only_left)
-        return None
+        return True  # no_vaccine = True
 
     print(f"{found.get('orgName')} 에서 백신을 {found.get('leftCounts')}개 발견했습니다.")
     print(f"주소는 : {found.get('address')} 입니다.")
@@ -114,11 +113,10 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
         vaccine_found_code = vaccine_type
         print(f"{vaccine_found_code} 으로 예약을 시도합니다.")
 
-    if vaccine_found_code and try_reservation(organization_code, vaccine_found_code, cookie):
-        return None
-    else:
-        find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bottom_y, only_left)
-        return None
+    if vaccine_found_code:
+        try_reservation(organization_code, vaccine_found_code, cookie)
+
+    return True  # no_vaccine = True
 
 
 def try_reservation(organization_code, vaccine_type, jar):

--- a/kakao/request.py
+++ b/kakao/request.py
@@ -126,8 +126,7 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
                     print(f"{x.get('vaccineName')} 백신을 {x.get('leftCount')}개 발견했습니다.")
                     vaccine_found_code = vaccine_type
                     print(f"{vaccine_found_code} 으로 예약을 시도합니다.")        
-                    if try_reservation(organization_code, vaccine_found_code, cookie):
-                        return None
+                    try_reservation(organization_code, vaccine_found_code, cookie)
             if not is_vac:
                 print(f"{vaccine_type} 백신은 없습니다.")
                 

--- a/kakao/request.py
+++ b/kakao/request.py
@@ -33,9 +33,11 @@ headers_vaccine = {
     "Keep-Alive": "timeout=5, max=1000"
 }
 
+banlist = {}
 
 # pylint: disable=too-many-locals,too-many-statements,too-many-branches,too-many-arguments
 def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bottom_y, only_left):
+    global banlist
     url = 'https://vaccine-map.kakao.com/api/v3/vaccine/left_count_by_coords'
     data = {"bottomRight": {"x": bottom_x, "y": bottom_y}, "onlyLeft": only_left, "order": "count",
             "topLeft": {"x": top_x, "y": top_y}}
@@ -52,6 +54,10 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
                 json_data = json.loads(response.text)
 
                 for x in json_data.get("organizations"):
+                    orgName = x.get('orgName')
+                    if orgName in banlist.keys() and banlist[orgName] == x.get('leftCounts'):
+                        # it is banned.
+                        continue
                     if x.get('status') == "AVAILABLE" or x.get('leftCounts') != 0:
                         found = x
                         all_list.append(x)
@@ -128,6 +134,7 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
                     print(f"{vaccine_found_code} 으로 예약을 시도합니다.")        
                     try_reservation(organization_code, vaccine_found_code, cookie)
             if not is_vac:
+                banlist[y.get('orgName')] = y.get('leftCounts')
                 print(f"{vaccine_type} 백신은 없습니다.")
                 
 

--- a/kakao/request.py
+++ b/kakao/request.py
@@ -41,6 +41,7 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
             "topLeft": {"x": top_x, "y": top_y}}
     done = False
     found = None
+    all_list = []
 
     while not done:
         try:
@@ -53,12 +54,14 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
                 for x in json_data.get("organizations"):
                     if x.get('status') == "AVAILABLE" or x.get('leftCounts') != 0:
                         found = x
+                        all_list.append(x)
                         done = True
-                        break
 
                 if not done:
                     pretty_print(json_data)
                     print(datetime.now())
+                else:
+                    break
 
             except json.decoder.JSONDecodeError as decodeerror:
                 print("JSONDecodeError : ", decodeerror)
@@ -91,14 +94,13 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
         find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bottom_y, only_left)
         return None
 
-    print(f"{found.get('orgName')} 에서 백신을 {found.get('leftCounts')}개 발견했습니다.")
-    print(f"주소는 : {found.get('address')} 입니다.")
-    organization_code = found.get('orgCode')
-
     # 실제 백신 남은수량 확인
     vaccine_found_code = None
 
     if vaccine_type == "ANY":  # ANY 백신 선택
+        print(f"{found.get('orgName')} 에서 백신을 {found.get('leftCounts')}개 발견했습니다.")
+        print(f"주소는 : {found.get('address')} 입니다.")
+        organization_code = found.get('orgCode')
         check_organization_url = f'https://vaccine.kakao.com/api/v3/org/org_code/{organization_code}'
         check_organization_response = requests.get(check_organization_url, headers=headers_vaccine, cookies=cookie, verify=False)
         check_organization_data = json.loads(check_organization_response.text).get("lefts")
@@ -111,8 +113,25 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
                 print(f"{x.get('vaccineName')} 백신이 없습니다.")
 
     else:
-        vaccine_found_code = vaccine_type
-        print(f"{vaccine_found_code} 으로 예약을 시도합니다.")
+        for y in all_list:
+            print(f"{y.get('orgName')} 에서 백신을 {y.get('leftCounts')}개 발견했습니다.")
+            print(f"주소는 : {y.get('address')} 입니다.")
+            organization_code = y.get('orgCode')
+            check_organization_url = f'https://vaccine.kakao.com/api/v3/org/org_code/{organization_code}'
+            check_organization_response = requests.get(check_organization_url, headers=headers_vaccine, cookies=cookie, verify=False)
+            check_organization_data = json.loads(check_organization_response.text).get("lefts")
+            is_vac = False
+            for x in check_organization_data:
+                if x.get('vaccineCode') == vaccine_type and x.get('leftCount') != 0:
+                    is_vac = True
+                    print(f"{x.get('vaccineName')} 백신을 {x.get('leftCount')}개 발견했습니다.")
+                    vaccine_found_code = vaccine_type
+                    print(f"{vaccine_found_code} 으로 예약을 시도합니다.")        
+                    if try_reservation(organization_code, vaccine_found_code, cookie):
+                        return None
+            if not is_vac:
+                print(f"{vaccine_type} 백신은 없습니다.")
+                
 
     if vaccine_found_code and try_reservation(organization_code, vaccine_found_code, cookie):
         return None

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -19,7 +19,9 @@ def main_function():
         vaccine_type, top_x, top_y, bottom_x, bottom_y, only_left = input_config()
     else:
         vaccine_type, top_x, top_y, bottom_x, bottom_y = previous_used_type, previous_top_x, previous_top_y, previous_bottom_x, previous_bottom_y
-    find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bottom_y, only_left)
+    no_vaccine = True
+    while no_vaccine:
+        no_vaccine = find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bottom_y, only_left)
     close()
 
 


### PR DESCRIPTION
#942 이슈에 대해 무의미해진 `ANY` 옵션을 삭제하고 여러 개의 백신을 선택할 수 있도록 수정했습니다.
백신 코드 입력 시 `VEN00014, VEN00013` 와 같이 입력하면 먼저 모더나를 찾고, 없으면 화이자를 찾습니다.

잔여백신이 가장 많은 접종 기관부터 백신 종류를 요청하고, 원하는 백신이 없으면 다음 기관으로 넘어갑니다.

다만 모든 기관에 대해 요청을 보내다 보니 좀 느려져서, `search_time`을 `0`으로 설정해도 0.5초 정도 소요됩니다.